### PR TITLE
Add a note about limitation

### DIFF
--- a/docs/articles/architecture/handling-clear-text-passwords/README.md
+++ b/docs/articles/architecture/handling-clear-text-passwords/README.md
@@ -66,8 +66,9 @@ Few points to remember before trying out the keystore tool for Elasticsearch
 Obfuscating passwords in Elasticsearch configuration file
 ---------------------------------------------------------
 
-:information_source: 
-There is a limitation from API Gateway version 10.5 in which search guard related sensitive information cannot be obfusticated using the elasticsearch Keystore.  Only the elasticsearch password can be obfusticated.
+> **Note:**
+> 
+> There is a limitation from API Gateway version 10.5 in which search guard related sensitive information cannot be obfusticated using the elasticsearch Keystore.  Only the elasticsearch password can be obfusticated.
 
 ### Creating a keystore in Elasticsearch
 

--- a/docs/articles/operations/API Gateway migration steps - Simplified/Migrating standalone API Gateway using Direct mode/README.md
+++ b/docs/articles/operations/API Gateway migration steps - Simplified/Migrating standalone API Gateway using Direct mode/README.md
@@ -97,7 +97,7 @@ If the source Elasticsearch is protected with HTTPS, add the source certificates
 
 Below is a sample command to import the truststore of source Elasticsearch in to target Elasticsearch JVM.
 
-_**$<TARGET>\\jvm\\jvm\\bin\\keytool -import -keystore <TARGET>\\jvm\\jvm\\jre\\lib\\security\\cacerts -file <truststore.jks>-alias <alias>**_
+_**$<TARGET>\\jvm\\jvm\\bin\\keytool -import -keystore <TARGET>\\jvm\\jvm\\jre\\lib\\security\\cacerts -file <truststore.jks> -alias <alias>**_
 
 | **Property**     | **Detail**                                                   | **Example**             |
 | ---------------- | ------------------------------------------------------------ | ----------------------- |


### PR DESCRIPTION
Added a note about the 10.5 limitations in which search guard related sensitive information cannot be obfusticated using the elastic search Keystore